### PR TITLE
FIX: "to weight the flour" => "to weigh the flour"

### DIFF
--- a/content/cookies/index.txt
+++ b/content/cookies/index.txt
@@ -80,7 +80,7 @@ Want extra good cookies? Follow some or all of these advanced tips to get better
 
 #### While Making
 
-* Use a kitchen scale to weight the flour.
+* Use a kitchen scale to weigh the flour.
 * Sift the flour with salt, baking soda before adding to sugar/butter.
 * Let sugar and melted butter sit in fridge for ~30 minutes after mixing.
 


### PR DESCRIPTION
Corrects typo to the likely intended verb.

Unrelated, both of the image links are incorrect. They aren't at the root of the site, nor in a cookies subfolder.